### PR TITLE
Adding local boost support to CMake configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,19 +25,29 @@ endif()
 ## TODO: Add options for on utilizing in house builds
 include(FetchContent)
 FetchContent_Declare(
-  kokkos
-  URL https://github.com/kokkos/kokkos/archive/refs/tags/4.0.00.zip
+kokkos
+URL https://github.com/kokkos/kokkos/archive/refs/tags/4.0.00.zip
 )
 FetchContent_MakeAvailable(kokkos)
 
 FetchContent_Declare(
         yaml
-	URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.zip
+        URL https://github.com/jbeder/yaml-cpp/archive/refs/tags/yaml-cpp-0.7.0.zip
 )
 FetchContent_MakeAvailable(yaml)
 include_directories(BEFORE SYSTEM ${yaml_SOURCE_DIR} ${yaml_BINARY_DIR}/include)
 
-add_subdirectory(boost-cmake)
+# Try finding boost and if not found install.
+find_package(Boost 1.73.0 COMPONENTS program_options filesystem)
+
+if (NOT ${Boost_FOUND})
+        add_subdirectory(boost-cmake)
+else ()
+        message(STATUS "    LIB:   ${Boost_LIBRARY_DIRS}")
+        message(STATUS "    INC:   ${Boost_INCLUDE_DIRS}")
+        message(STATUS "    LIBSO: ${Boost_LIBRARIES}")
+endif()
+#message( FATAL_ERROR "EXITING BECAUSE I WANT TO.")
 
 configure_file(constants.hpp.in constants.hpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ FetchContent_MakeAvailable(yaml)
 include_directories(BEFORE SYSTEM ${yaml_SOURCE_DIR} ${yaml_BINARY_DIR}/include)
 
 # Try finding boost and if not found install.
-find_package(Boost 1.73.0 COMPONENTS program_options filesystem)
+find_package(Boost 1.73.0 COMPONENTS program_options filesystem system)
 
 if (NOT ${Boost_FOUND})
         add_subdirectory(boost-cmake)
@@ -47,7 +47,6 @@ else ()
         message(STATUS "    INC:   ${Boost_INCLUDE_DIRS}")
         message(STATUS "    LIBSO: ${Boost_LIBRARIES}")
 endif()
-#message( FATAL_ERROR "EXITING BECAUSE I WANT TO.")
 
 configure_file(constants.hpp.in constants.hpp)
 

--- a/docs/user_documentation/requirements.rst
+++ b/docs/user_documentation/requirements.rst
@@ -44,6 +44,12 @@ Compiler Versions
       * 20.1
       * 20.1
 
+.. warning::
+
+    There seem to be issues with ``cudatoolkit/11.1``. We have successfully
+    compiled the package with versions ``>=11.7``. For a list of tested
+    compilers and platforms, see :ref:`tests` section.
+
 Build system
 ------------
 

--- a/docs/user_documentation/requirements.rst
+++ b/docs/user_documentation/requirements.rst
@@ -55,3 +55,23 @@ Build system
 
 * CMake >= 3.16: required
 * CMake >= 3.21.1 for NVC++
+
+
+Dependencies
+------------
+
+None of the dependencies need to be installed prior to the installation of
+the package. Having installed some packages does however reduce build time
+because the dependencies do not have to be fetched.
+
+Boost
++++++
+
+Current requirements of the ``Boost`` library are a version that is ``>=1.66.0``.
+If you have ``Boost`` installed on your system, set the environment variable
+``BOOST_ROOT`` containing the absolute path to your ``Boost`` installation. On
+most machines, this can be done using
+
+.. code:: bash
+
+    module load boost/?.??.? # Eg. boost/1.73.0

--- a/docs/user_documentation/requirements.rst
+++ b/docs/user_documentation/requirements.rst
@@ -69,8 +69,9 @@ Boost
 
 Current requirements of the ``Boost`` library are a version that is ``>=1.66.0``.
 If you have ``Boost`` installed on your system, set the environment variable
-``BOOST_ROOT`` containing the absolute path to your ``Boost`` installation. On
-most machines, this can be done using
+``BOOST_ROOT`` containing the absolute path to your ``Boost`` installation.
+For example, on machines (clusters) with ``lmod`` package manager this can be
+done by loading the boost module
 
 .. code:: bash
 


### PR DESCRIPTION
# Description

Added CMake feature to look for local boost.

If `boost>=1.73.0` is installed and `$BOOST_ROOT` is `cmake` will look for as well as the necessary components. If the necessary components cannot be found, `cmake` will install 

On Della:

```bash
# in addition to other compiler modules:
module load boost/1.73.0

cmake3 -S . -B build_cpu
cmake3 --build build_cpu -j
```


# Issue Number

Partially fixes #63 

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [x] My code passes all the integration tests
- [ ] ~I have added sufficient unittests to test my changes~
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms? _CAN I TEST THIS_?
