### PR TITLE
Compile tests only when required - Only compile tests when BUILD_TESTS flags is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(specfem2d_kokkos VERSION 0.1.0)
 
 set(CMAKE_CXX_STANDARD 17)
 option(MPI_PARALLEL "MPI enabled" OFF)
+option(BUILD_TESTS "Tests included" OFF)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
         set(CMAKE_CXX_FLAGS "-fp-model=precise")
@@ -286,6 +287,7 @@ target_link_libraries(
 
 # Include tests
 if (BUILD_TESTS)
+        message("-- Including tests.")
         add_subdirectory(tests/unit-tests)
         add_subdirectory(tests/regression-tests)
         add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,9 +285,11 @@ target_link_libraries(
 )
 
 # Include tests
-add_subdirectory(tests/unit-tests)
-add_subdirectory(tests/regression-tests)
-add_subdirectory(examples)
+if (BUILD_TESTS)
+        add_subdirectory(tests/unit-tests)
+        add_subdirectory(tests/regression-tests)
+        add_subdirectory(examples)
+endif()
 
 # Doxygen
 

--- a/docs/user_documentation/installation.rst
+++ b/docs/user_documentation/installation.rst
@@ -47,3 +47,9 @@ Finally, once compiled you could run specfem from inside the build directory, by
 .. code-block:: bash
 
     export PATH=${PATH}:<location to build directory>
+
+Testing Installation
+=====================
+
+To check if the compilation is successful, compile and run the tests, then build the code with ``-DBUILD_TESTS=ON``. Then, run the test by ``cd build/tests/unit-tests  && ctest``.
+


### PR DESCRIPTION
# Description

Added BUILD_TESTS flag to `CMakeLists.txt`. The default is set to OFF. To enable BUILD_TESTS flag, added `-DBUILD_TESTS=ON` to the command during the compilation.

# Issue Number

Issue [#63](https://github.com/PrincetonUniversity/specfem2d_kokkos/issues/63)

# Checklist

Please make sure to check developer documentation on specfem docs. 

- [x] I ran the code through pre-commit to check style
- [ ] My code passes all the integration tests
- [ ] I have added sufficient unittests to test my changes
- [x] I have added/updated documentation for the changes I am proposing
- [x] I have updated CMakeLists to ensure my code builds
- [ ] My code builds across all platforms 
